### PR TITLE
feat(inference): add vLLM inference

### DIFF
--- a/autocrit/inference/__init__.py
+++ b/autocrit/inference/__init__.py
@@ -1,1 +1,1 @@
-from .inference_hook import vLLMHook
+from .inference_hook import vLLMHook, HuggingFaceHook

--- a/autocrit/inference/__init__.py
+++ b/autocrit/inference/__init__.py
@@ -1,1 +1,1 @@
-from .inference_hook import vLLMHook, HuggingFaceHook
+from .inference_hook import vLLMHook, HuggingFaceHook, RewardHook, OpenAIHook

--- a/autocrit/inference/__init__.py
+++ b/autocrit/inference/__init__.py
@@ -1,0 +1,1 @@
+from .inference_hook import VLLMHook

--- a/autocrit/inference/__init__.py
+++ b/autocrit/inference/__init__.py
@@ -1,1 +1,1 @@
-from .inference_hook import VLLMHook
+from .inference_hook import vLLMHook

--- a/autocrit/inference/inference_hook.py
+++ b/autocrit/inference/inference_hook.py
@@ -87,10 +87,10 @@ class vLLMHook(InferenceHook):
                         if output.startswith("Submitted batch job"):
                             self.job_ids.append(output.split()[-1].strip())
 
-                while not os.path.exists(f"{self.job_ids[-1]}"):
+                while not os.path.exists(f"vllm_logs/{self.job_ids[-1]}"):
                     time.sleep(1)
 
-                with open(f"{self.job_ids[-1]}") as log:
+                with open(f"vllm_logs/{self.job_ids[-1]}") as log:
                     while True:
                         output = log.readline().strip()
                         if output:

--- a/autocrit/inference/inference_hook.py
+++ b/autocrit/inference/inference_hook.py
@@ -71,7 +71,7 @@ class vLLMHook(InferenceHook):
         if num_external_nodes:
             self.job_ids = []
             self.servers = []
-            self.data_parallel_size = torch.cuda.device_count() * num_nodes // tensor_parallel_size
+            self.data_parallel_size = torch.cuda.device_count() * num_external_nodes // tensor_parallel_size
 
             sbatch_script_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "vllm.sbatch")
             for _ in range(num_external_nodes):

--- a/autocrit/inference/inference_hook.py
+++ b/autocrit/inference/inference_hook.py
@@ -1,51 +1,64 @@
-import signal
-import aiohttp
+import argparse
 import asyncio
 import json
-import subprocess
-import torch
-import time
-from tqdm.asyncio import tqdm_asyncio
-
-from abc import ABC, abstractmethod
-import argparse
+import logging
 import os
+import signal
+import subprocess
+import sys
+import time
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple
+
+import aiohttp
 import torch
 import transformers
-from typing import Tuple, Any, Optional, List, Dict
 import tritonclient.grpc.aio as grpcclient
-from autocrit.inference.utils import triton_call, best_of_n
+from autocrit.inference.utils import best_of_n, triton_call
 from text_generation import Client
-import logging
-
-import signal
-import sys
+from tqdm.asyncio import tqdm_asyncio
 
 
 class InferenceHook(ABC):
     def __init__(self, **kwargs):
         """
-        kwargs: a dictionary of parameters to initilize the model
+        Args:
+            kwargs (`Dict[str, Any]`): a dictionary of parameters to initilize the model with
         """
         pass
 
     @abstractmethod
-    def generate(self, prompts: List[str], **kwargs: Dict[str, Any]):
+    def generate(self, prompts: List[str], **kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
-        prompts: inputs for generations
-        kwargs: parameters to control generation
+        Args:
+            prompts (`List[str]`): inputs for generations
+            kwargs (`Dict[str, Any]`): parameters to control generation
+
+        Returns:
+            outputs (`List[Dict[str, Any]]`): a list of dictionaries, each dictionary contains the following keys:
+                id (`int`): the id of the prompt
+                prompt (`str`): the prompt
+                outputs (`List[str]`): a list of outputs per prompt
         """
         pass
 
     @abstractmethod
     def free(self):
         """
-        Clean up resources after inference
+        Clean up resources after the inference
         """
         pass
 
 class vLLMHook(InferenceHook):
     def __init__(self, model_path, tensor_parallel_size=1, external=False, num_nodes=1):
+        """
+
+        Args:
+            model_path (`str`): the path to the model
+            tensor_parallel_size (`int`): the number of GPUs to use per one server
+            external (`bool`): whether to spawn a new slurm jobs and generate on external nodes or use the current node
+            num_nodes (`int`): the number of nodes to use if external is True
+        """
         self.init_time = time.time()
         self.model_path = model_path
         self.tensor_parallel_size = tensor_parallel_size
@@ -63,8 +76,7 @@ class vLLMHook(InferenceHook):
             sbatch_script_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "vllm.sbatch")
             for _ in range(num_nodes):
                 cmd = f"sbatch {sbatch_script_path} NUM_TP={tensor_parallel_size} MODEL_PATH={model_path} DEVICES={'|'.join(devices)}"
-                print(f'{cmd=}')
-                process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={**os.environ, "TORCHELASTIC_USE_AGENT_STORE": ""})
+                process = subprocess.Popen(cmd.split(), env={**os.environ, "TORCHELASTIC_USE_AGENT_STORE": ""})
 
                 while True:
                     output = process.stdout.readline().decode("utf-8").strip()
@@ -94,7 +106,12 @@ class vLLMHook(InferenceHook):
             self.processes = []
             for i in range(self.data_parallel_size):
                 cmd = f"python -m vllm.entrypoints.api_server -tp={tensor_parallel_size} --model={model_path} --port {8000+i}"
-                process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={**os.environ, "CUDA_VISIBLE_DEVICES": devices[i], "TORCHELASTIC_USE_AGENT_STORE": ""})
+                kwargs = {"env": {**os.environ, "CUDA_VISIBLE_DEVICES": devices[i], "TORCHELASTIC_USE_AGENT_STORE": ""}}
+                if not os.environ.get("DEBUG", False):
+                    kwargs["stdout"] = subprocess.DEVNULL
+                    kwargs["stderr"] = subprocess.DEVNULL
+
+                process = subprocess.Popen(cmd.split(), **kwargs)
                 self.processes.append(process)
 
             print(f"Loading {self.data_parallel_size} processes for {model_path}...")
@@ -138,7 +155,7 @@ class vLLMHook(InferenceHook):
                     return {"id": i, "prompt": prompt, "outputs": [None]}
 
 
-    def generate(self, prompts, **kwargs):
+    def generate(self, prompts: List[str], **kwargs) -> List[Dict[str, Any]]:
         async def generate_vllm_api(prompts, **kwargs):
             outputs = [self.request_vllm_api(prompt=prompt, i=i, **kwargs) for i, prompt in enumerate(prompts)]
             return await tqdm_asyncio.gather(*outputs, desc=f"Inferencing {self.model_path}")
@@ -152,19 +169,30 @@ class vLLMHook(InferenceHook):
 
     def free(self):
         if self.external:
-            subprocess.run(f"scancel {' '.join(self.job_ids)}".split())
+            if self.job_ids:
+                subprocess.run(f"scancel {' '.join(self.job_ids)}".split())
+                self.job_ids = []
         else:
             for p in self.processes:
                 os.kill(p.pid, signal.SIGTERM)
                 p.communicate()
             print(f"Unloaded all {self.model_path} processes")
+            self.processes = []
 
     def __del__(self):
         self.free()
 
-# Inference hook that uses the HuggingFace API to call a model
 class HuggingFaceHook(InferenceHook):
+    """
+    Inference hook that uses plain HuggingFace transformers API
+    """
+
     def __init__(self, model_path: str, tokenizer_path : Optional[str] = None):
+        """
+        Args:
+            model_path (`str`): the directory of the model
+            tokenizer_path (`str`): the directory of the tokenizer, if None, the `model_path` is implied
+        """
         self.model = transformers.AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
         self.tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_path or model_path)
         if self.tokenizer.pad_token is None:
@@ -199,101 +227,89 @@ class HuggingFaceHook(InferenceHook):
         del self.model
         del self.tokenizer
 
-# Inference hook that uses the HuggingFace API to call a model. Uses the best of N sampling method
 class HuggingFaceHookBestOfN(HuggingFaceHook):
-    def __init__(self, dir : str, tokenizer_name : Optional[str] = None):
-        """
-        dir: the directory of the model
-        tokenizer_name: the name of the tokenizer to use, if None, use the model name
-        """
-        super().__init__(dir, tokenizer_name)
+    """
+    Inference hook that uses the HuggingFace API to call a model. Uses the best of N sampling method
+    """
 
-    def infer(self, input_texts : List[str],
-              generate_params : Dict[str, Any],
-              **kwargs: Any) -> Any:
+    def __init__(self, model_path: str, tokenizer_path : Optional[str] = None):
         """
-        input_texts: a list of strings, each string is a prompt
-        generate_params: a dictionary of parameters to pass to the generate function
-        kwargs: any additional arguments to pass to the generate function
-        returns: a list of strings, each string is a generated output
+        Args:
+            model_path (`str`): the directory of the model
+            tokenizer_path (`str`): the directory of the tokenizer, if None, the `model_path` is implied
+        """
+        super().__init__(model_path, tokenizer_path)
+
+    def generate(self, prompts: List[str], **kwargs: Any) -> List[str]:
+        """
+        Args:
+            prompts: a list of prompts to generate
+            kwargs: a dictionary of parameters to pass to the generate function
         """
 
-        output_txt = best_of_n(self.model, self.tokenizer, input_texts, gen_kwargs=generate_params, **kwargs)
+        output_txt = best_of_n(self.model, self.tokenizer, prompts, gen_kwargs=kwargs)
         return output_txt
 
 
 class TritonHook(InferenceHook):
-    def __init__(self, dir : str, model_name : str, tokenizer_name : Optional[str] = None):
+    def __init__(self, url: str, model_path: str, tokenizer_path : Optional[str] = None):
         """
-        dir: location of the triton server
-        model_name: the name of the model to use
-        tokenizer_name: the name of the tokenizer to use, if None, use the model name
+        Args:
+            url (`str`): location of the triton server
+            model_path (`str`): the name of the model to use
+            tokenizer_path (`str`): the name of the tokenizer to use, if None, the `model_path` is implied
         """
-        super().__init__(dir)
-        self.url = dir # url contains host:port
+        self.url = url # url contains host:port
         # TODO: if URL is a path to a triton model, we shold load the model and launch the server
-        self.model_name = model_name
-        if tokenizer_name is None:
-            self.tokenizer_name = model_name
+        self.model_path = model_path
+        if tokenizer_path is None:
+            self.tokenizer_path = model_path
         else:
-            self.tokenizer_name = tokenizer_name
+            self.tokenizer_path = tokenizer_path
 
-        self.client = None
-        self.tokenizer = None
-
-    def load(self, **kwargs):
         # create a client using url
         self.client = grpcclient.InferenceServerClient(url=self.url)
-        self.tokenizer = transformers.AutoTokenizer.from_pretrained(self.tokenizer_name)
+        self.tokenizer = transformers.AutoTokenizer.from_pretrained(self.tokenizer_path)
         # check if there is a padding token, if not add one
         if self.tokenizer.pad_token is None:
             self.tokenizer.add_special_tokens({"pad_token": "[PAD]"})
 
 
-    def infer(self, input_texts : List[str],
-              generate_params : Dict[str, Any],
-              **kwargs: Any) -> Any:
+    def generate(self, prompts: List[str], **kwargs: Any) -> List[str]:
         """
-        input_texts: a list of strings, each string is a prompt
-        generate_params: a dictionary of parameters to pass to the generate function
-        kwargs: any additional arguments to pass to the generate function
-        returns: a list of strings, each string is a generated output
+        Args:
+            prompts: a list of prompts to generate
+            kwargs: a dictionary of parameters to pass to the generate function
         """
 
         # use self.client to call the model
         # assume input and output are batched
-        inp_text = input_texts
-        inps = self.tokenizer(inp_text, return_tensors="pt", padding=True)
+        inps = self.tokenizer(prompts, return_tensors="pt", padding=True)
         # call infer
-        logits, output_txt = triton_call(self.client, self.model_name, inps.input_ids, **generate_params)
+        logits, output_txt = triton_call(self.client, self.model_path, inps.input_ids, **kwargs)
 
         if not "no_decode" in kwargs:
             output_txt = self.tokenizer.batch_decode(output_txt, skip_special_tokens=True)
 
         # check if logits are needed
-        if generate_params["return_logits"]:
+        if kwargs["return_logits"]:
             return output_txt, logits
         else:
             return output_txt
 
 
-# Inference hook that uses the HuggingFace API to call a model
 class TextGenerationHook(InferenceHook):
-    def __init__(self, dir : str):
-        super().__init__(dir)
-        self.model_name = dir
-        self.client = None
-
-    def load(self, **kwargs):
+    def __init__(self, model_path: str):
+        self.model_path = model_path
         # get num shards and port, used for the launcher script
         num_shards = kwargs.get("num_shards", 1)
         port = kwargs.get("port", 8080)
 
         # check if model name is a URL
-        if not self.model_name.startswith("http"):
+        if not self.model_path.startswith("http"):
             # launch the model using the model name and text_generation_launcher.sh
             # The following line runs the launcher script
-            output = subprocess.run(["sbatch./launch.sbatch MODEL_NAME="+str(self.model_name) + " NUM_SHARD="+str(num_shards) + " PORT="+str(port)], capture_output=True)
+            output = subprocess.run(["sbatch./launch.sbatch MODEL_NAME="+str(self.model_path) + " NUM_SHARD="+str(num_shards) + " PORT="+str(port)], capture_output=True)
             logging.info(output.stdout.decode("utf-8"))
             # check return code
             if output.returncode != 0:
@@ -317,22 +333,18 @@ class TextGenerationHook(InferenceHook):
             # Create the client
             self.client = Client(f"http://{ip}:{port}")
         else:
-            self.client = Client(self.model_name)
+            self.client = Client(self.model_path)
 
-    def infer(self, input_texts : List[str],
-              generate_params : Dict[str, Any],
-              **kwargs: Any) -> Any:
+    def generate(self, prompts: List[str], **kwargs: Dict[str, Any]) -> List[str]:
         """
-        input_texts: a list of strings, each string is a prompt
-        generate_params: a dictionary of parameters to pass to the generate function
-        kwargs: any additional arguments to pass to the generate function
-        returns: a list of strings, each string is a generated output
+        Args:
+            prompts (`List[str]`): a list of strings, each string is a prompt
+            kwargs (`Dict[str, Any]`): a dictionary of parameters to pass to the generate function
         """
         # if input_texts is a list, convert it to a string
         if isinstance(input_texts, list):
             input_texts = input_texts[0]
 
         # use self.client to call the model
-        output_txt = self.client.generate(input_texts, **generate_params).generated_text
-        #print(output_txt)
+        output_txt = self.client.generate(input_texts, **kwargs).generated_text
         return output_txt

--- a/autocrit/inference/inference_hook.py
+++ b/autocrit/inference/inference_hook.py
@@ -43,7 +43,7 @@ class InferenceHook:
         """
         pass
 
-class VLLMHook:
+class vLLMHook:
     def __init__(self, model_path, tensor_parallel_size=1):
         self.data_parallel_size = torch.cuda.device_count() // tensor_parallel_size
         self.tensor_parallel_size = tensor_parallel_size

--- a/autocrit/inference/inference_hook.py
+++ b/autocrit/inference/inference_hook.py
@@ -1,3 +1,4 @@
+import signal
 import aiohttp
 import asyncio
 import json
@@ -6,6 +7,7 @@ import torch
 import time
 from tqdm.asyncio import tqdm_asyncio
 
+from abc import ABC, abstractmethod
 import argparse
 import os
 import torch
@@ -22,54 +24,58 @@ This gives us significantly improved flexibility, as autocrit is not built aroun
 '''
 
 
-# Inference hook that takes a model and a batch of inputs and returns a batch of outputs
-class InferenceHook:
-    def __init__(self, dir : str):
-        self.dir = dir
-        self.API_KEY = ""
-        self.API_URL = ""
-
-    def load(self, **kwargs):
-        pass
-
-    # Calls the inference API and returns the result
-    def infer(self, input_texts : List[str],
-              generate_params : Dict[str, Any],
-              **kwargs: Any) -> Any:
+class InferenceHook(ABC):
+    def __init__(self, **kwargs):
         """
-        input_texts: a list of strings, each string is a prompt
-        generate_params: a dictionary of parameters to pass to the generate function
-        kwargs: any additional arguments to pass to the generate function
+        kwargs: a dictionary of parameters to pass to initilize the model
         """
         pass
 
-class vLLMHook:
+    @abstractmethod
+    def generate(self, prompts: List[str], **kwargs: Dict[str, Any]):
+        """
+        prompts: a list of strings, each string is a prompt
+        kwargs: a dictionary of parameters to pass to the generate function
+        """
+        pass
+
+    @abstractmethod
+    def unload(self):
+        pass
+
+class vLLMHook(InferenceHook):
     def __init__(self, model_path, tensor_parallel_size=1):
-        self.data_parallel_size = torch.cuda.device_count() // tensor_parallel_size
+        self.model_path = model_path
         self.tensor_parallel_size = tensor_parallel_size
+        self.data_parallel_size = torch.cuda.device_count() // tensor_parallel_size
+        self.nth_request = 0
 
         devices = list(map(str, range(torch.cuda.device_count())))
-        devices = [",".join(devices[i:i+tensor_parallel_size]) for i in range(self.data_parallel_size)]
+        devices = [",".join(devices[i*tensor_parallel_size:(i+1)*tensor_parallel_size]) for i in range(self.data_parallel_size)]
 
         self.processes = []
         for i in range(self.data_parallel_size):
             cmd = f"python -m vllm.entrypoints.api_server -tp={tensor_parallel_size} --model={model_path} --port {8000+i}"
-            process = subprocess.Popen(cmd.split(), env={**os.environ, "CUDA_VISIBLE_DEVICES": devices[i]})
+            process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={**os.environ, "CUDA_VISIBLE_DEVICES": devices[i]})
             self.processes.append(process)
+
+        print(f"Loading {self.data_parallel_size} processes for {model_path}...")
 
         while True:
             all_loaded = True
             try:
-                asyncio.run(self.request_vllm_api(prompt="", port=8000 + self.data_parallel_size-1))
+                asyncio.run(self.request_vllm_api(prompt=""))
             except aiohttp.client_exceptions.ClientConnectorError:
                 all_loaded = False
 
             if all_loaded:
+                print(f"Loaded {model_path}")
+                time.sleep(5)
                 break
 
             time.sleep(1)
 
-    async def request_vllm_api(self, prompt: str, i = 0, port=8000, n=1, temperature=0.0, max_new_tokens=512, stop=[]):
+    async def request_vllm_api(self, prompt: str, i=0, n=1, temperature=0.0, max_new_tokens=512, stop=[]):
         pload = {
             "prompt": prompt,
             "n": n,
@@ -79,6 +85,8 @@ class vLLMHook:
             "stream": False,
         }
 
+        port = 8000 + self.nth_request % self.data_parallel_size
+        self.nth_request += 1
         connector = aiohttp.TCPConnector(limit_per_host=1024)
         timeout = aiohttp.ClientTimeout(total=9000)
         async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
@@ -89,66 +97,53 @@ class vLLMHook:
                 except aiohttp.client.ContentTypeError:
                     return {"id": i, "prompt": prompt, "output": [None]}
 
+
     def generate(self, prompts, **kwargs):
         async def generate_vllm_api(prompts, **kwargs):
-            outputs = [self.request_vllm_api(prompt, i=i, **kwargs, port=8000 + i % self.data_parallel_size) for i, prompt in enumerate(prompts)]
-            return await tqdm_asyncio.gather(*outputs)
+            outputs = [self.request_vllm_api(prompt, i=i, **kwargs) for i, prompt in enumerate(prompts)]
+            return await tqdm_asyncio.gather(*outputs, desc=f"Inferencing {self.model_path}")
 
         return asyncio.run(generate_vllm_api(prompts, **kwargs))
 
-    def __del__(self):
+    def unload(self):
         for p in self.processes:
-            p.kill()
+            os.kill(p.pid, signal.SIGKILL)
+            p.communicate()
+        print(f"Offloaded all {self.model_path} processes")
 
 
 # Inference hook that uses the HuggingFace API to call a model
 class HuggingFaceHook(InferenceHook):
-    def __init__(self, dir : str, tokenizer_name : Optional[str] = None):
-        """
-        dir: the directory of the model
-        tokenizer_name: the name of the tokenizer to use, if None, use the model name
-        """
-        super().__init__(dir)
-        self.model_name = dir
-        if tokenizer_name is None:
-            self.tokenizer_name = dir
-        else:
-            self.tokenizer_name = tokenizer_name
-
-        self.model = None
-        self.tokenizer = None
-
-    def load(self, **kwargs):
-        # Load the model and tokenizer
-        self.model = transformers.AutoModelForCausalLM.from_pretrained(self.model_name)
-        self.tokenizer = transformers.AutoTokenizer.from_pretrained(self.tokenizer_name)
-
-        # check if there is a padding token, if not add one
+    def __init__(self, model_path: str, tokenizer_path : Optional[str] = None):
+        self.model = transformers.AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
+        self.tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_path or model_path)
         if self.tokenizer.pad_token is None:
             self.tokenizer.add_special_tokens({"pad_token": "[PAD]"})
 
-    def infer(self, input_texts : List[str],
-              generate_params : Dict[str, Any],
-              **kwargs: Any) -> Any:
-        """
-        input_texts: a list of strings, each string is a prompt
-        generate_params: a dictionary of parameters to pass to the generate function
-        kwargs: any additional arguments to pass to the generate function
-        returns: a list of strings, each string is a generated output
-        """
+    @torch.inference_mode()
+    def generate(self, prompts: List[str], **kwargs: Any) -> List[str]:
+        stop = kwargs.pop("stop", [])
 
-        # model.generate, use the tokenizer to convert the output to text and kwds for gen arguments
-        # assume input and output are batched
-        inp_text = input_texts
-        inps = self.tokenizer(inp_text, return_tensors="pt", padding=True).to(self.model.device)
+        inputs = self.tokenizer(prompts, return_tensors="pt", padding=True, truncation=True, max_length=kwargs.get("max_length", 2048)).to(self.model.device)
 
-        output_txt = self.model.generate(input_ids=inps.input_ids, attention_mask=inps.attention_mask, **generate_params)
+        all_ids = self.model.generate(**inputs, pad_token_id=self.tokenizer.pad_token_id, eos_token_id=self.tokenizer.eos_token_id, **kwargs)
+        output_ids = all_ids[:, inputs.input_ids.shape[1]:]
 
-        # if we need to decode the text
-        if not "no_decode" in kwargs:
-            output_txt = self.tokenizer.batch_decode(output_txt, skip_special_tokens=True)
+        if "no_decode" in kwargs:
+            return output
 
-        return output_txt
+        outputs = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+
+        for i in range(len(outputs)):
+            for s in stop:
+                if s in outputs[i]:
+                    outputs[i] = outputs[i][:outputs[i].index(s)]
+
+        return outputs
+
+    def unload(self):
+        del self.model
+        del self.tokenizer
 
 # Inference hook that uses the HuggingFace API to call a model. Uses the best of N sampling method
 class HuggingFaceHookBestOfN(HuggingFaceHook):

--- a/autocrit/inference/vllm.sbatch
+++ b/autocrit/inference/vllm.sbatch
@@ -1,14 +1,13 @@
 #!/bin/bash
 #SBATCH --job-name=vllm
 #SBATCH --partition=g80
-#SBATCH --account=carperai
+#SBATCH --account=stability
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --mem=0
 #SBATCH --cpus-per-task=64
-#SBATCH --output=%j
+#SBATCH --output=vllm_logs/%j
 #SBATCH --exclusive
-#SBATCH --exclude ip-26-0-158-175
 
 for ARGUMENT in "$@"
 do

--- a/autocrit/inference/vllm.sbatch
+++ b/autocrit/inference/vllm.sbatch
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=vllm
+#SBATCH --partition=g80
+#SBATCH --account=carperai
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --mem=0
+#SBATCH --cpus-per-task=64
+#SBATCH --output=%j
+#SBATCH --exclusive
+#SBATCH --exclude ip-26-0-158-175
+
+for ARGUMENT in "$@"
+do
+   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+
+   KEY_LENGTH=${#KEY}
+   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+
+   export "$KEY"="$VALUE"
+done
+
+# check if argument contains MODEL, NUMTP
+if [ -z "$MODEL_PATH" ] || [ -z "$NUM_TP" ]; then
+    echo "Please provide MODEL, NUM_TP"
+    exit 1
+fi
+
+# replace '|' with ' ' for cuda devices separator to iterate over
+export DEVICES=${DEVICES//|/ }
+export HOSTNAMES=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+
+echo MODEL_PATH=$MODEL_PATH
+echo NUM_TP=$NUM_TP
+echo DEVICES=$DEVICES
+echo HOSTNAME=$HOSTNAMES
+
+echo $VIRTUAL_ENV
+module load cuda/11.8
+
+ix=0
+for devices in $DEVICES; do
+    CUDA_VISIBLE_DEVICES=$devices python -m vllm.entrypoints.api_server -tp=$NUM_TP --model=$MODEL_PATH --host=0.0.0.0 --port $((8000+ix)) &
+    ix=$((ix+1))
+done
+
+wait

--- a/autocrit/inference/vllm.sbatch
+++ b/autocrit/inference/vllm.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=vllm
-#SBATCH --partition=g80
+#SBATCH --partition=g40
 #SBATCH --account=stability
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
@@ -8,6 +8,8 @@
 #SBATCH --cpus-per-task=64
 #SBATCH --output=vllm_logs/%j
 #SBATCH --exclusive
+
+ray stop
 
 for ARGUMENT in "$@"
 do


### PR DESCRIPTION
This PR adds vLLM inference in data parallel manner by launching multiple local servers in view of `tensor_parallel_size`

Usage:
```python
from autocrit.inference import vLLMHook
# setup servers
model = vLLMHook("meta-llama/Llama-2-7b-hf", tensor_parallel_size=1, num_external_nodes=8)
model.generate(["..."], temperature=1, stop=["</s>"])
# stop servers
model.free()
```

Usage for reward models:
```python
from autocrit.inference import RewardHook
model = RewardHook("reciprocate/rm_beluga-7b_hh-full")
scores = model.score(["..."])
model.free()
```